### PR TITLE
update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -540,7 +540,7 @@ class MySpec extends FlatSpec with TestContainersForAll {
     super.afterContainersStart(containers)
 
     containers match {
-      case mySqlContainer and postgreSQLContainer => println("your logic here")
+      case mySqlContainer and pgContainer => println("your logic here")
     }
   }
 
@@ -548,7 +548,7 @@ class MySpec extends FlatSpec with TestContainersForAll {
     super.beforeContainersStop(containers)
 
     containers match {
-      case mySqlContainer and postgreSQLContainer => println("your logic here")
+      case mySqlContainer and pgContainer => println("your logic here")
     }
   }
 

--- a/README.md
+++ b/README.md
@@ -517,8 +517,8 @@ class MySpec extends FlatSpec with TestContainerForAll {
   }
 
  it should "work" in withContainers { 
-   case postgreSQLContainer: PostgreSQLContainer =>
-     assert(postgreSQLContainer.jdbcUrl.nonEmpty) 
+   case pgContainer: PostgreSQLContainer =>
+     assert(pgContainer.jdbcUrl.nonEmpty) 
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -516,8 +516,9 @@ class MySpec extends FlatSpec with TestContainerForAll {
     }
   }
 
- "test" should "work" in withContainers { case postgreSQLContainer: PostgreSQLContainer =>
-    succeed
+ it should "work" in withContainers { 
+   case postgreSQLContainer: PostgreSQLContainer =>
+     assert(postgreSQLContainer.jdbcUrl.nonEmpty) 
   }
 }
 ```
@@ -551,7 +552,7 @@ class MySpec extends FlatSpec with TestContainersForAll {
     }
   }
 
-  it should "test" in withContainers {
+  it should "work" in withContainers {
     case mysqlContainer and pgContainer =>
       assert(mysqlContainer.jdbcUrl.nonEmpty && pgContainer.jdbcUrl.nonEmpty)
   }

--- a/README.md
+++ b/README.md
@@ -494,7 +494,7 @@ If you want to use a single container for each test in your suite just use code 
 You have the option to override `afterContainersStart` and `beforeContainersStop` methods.
 
 ##### Example with single container
-```
+```scala
 class MySpec extends FlatSpec with TestContainerForAll {
 
   override val containerDef: ContainerDef =
@@ -523,7 +523,7 @@ class MySpec extends FlatSpec with TestContainerForAll {
 ```
 
 #### Example with multiple containers
-```
+```scala
 class MySpec extends FlatSpec with TestContainersForAll {
 
   override type Containers = MySQLContainer and PostgreSQLContainer

--- a/README.md
+++ b/README.md
@@ -490,6 +490,75 @@ class ExampleSpec extends FunSuite with TestContainersForAll {
 
 If you want to use a single container for each test in your suite just use code above with `TestContainersForEach` trait instead of `TestContainersForAll`.
 
+#### Start/Stop hooks
+You have the option to override `afterContainersStart` and `beforeContainersStop` methods.
+
+##### Example with single container
+```
+class MySpec extends FlatSpec with TestContainerForAll {
+
+  override val containerDef: ContainerDef =
+    PostgreSQLContainer.Def("postgres:12")
+
+  override def afterContainersStart(container: Containers): Unit = {
+    super.afterContainersStart(container)
+
+    container match {
+      case _: PostgreSQLContainer => println("your logic here")
+    }
+  }
+
+  override def beforeContainersStop(container: Containers): Unit = {
+    super.beforeContainersStop(container)
+
+    container match {
+      case _: PostgreSQLContainer => println("your logic here")
+    }
+  }
+
+ "test" should "work" in withContainers { case postgreSQLContainer: PostgreSQLContainer =>
+    succeed
+  }
+}
+```
+
+#### Example with multiple containers
+```
+class MySpec extends FlatSpec with TestContainersForAll {
+
+  override type Containers = MySQLContainer and PostgreSQLContainer
+
+  override def startContainers(): Containers = {
+    val container1 = MySQLContainer.Def().start()
+    val container2 = PostgreSQLContainer.Def().start()
+
+    container1 and container2
+  }
+
+  override def afterContainersStart(containers: Containers): Unit = {
+    super.afterContainersStart(containers)
+
+    containers match {
+      case mySqlContainer and postgreSQLContainer => println("your logic here")
+    }
+  }
+
+  override def beforeContainersStop(containers: Containers): Unit = {
+    super.beforeContainersStop(containers)
+
+    containers match {
+      case mySqlContainer and postgreSQLContainer => println("your logic here")
+    }
+  }
+
+  it should "test" in withContainers {
+    case mysqlContainer and pgContainer =>
+      assert(mysqlContainer.jdbcUrl.nonEmpty && pgContainer.jdbcUrl.nonEmpty)
+  }
+
+}
+```
+
 #### Notes on MUnit usage
 - If you use `*ForAll` trait and override beforeAll() without calling super.beforeAll() your containers won't start.
 - If you use `*ForAll` trait and override afterAll() without calling super.afterAll() your containers won't stop.

--- a/README.md
+++ b/README.md
@@ -523,7 +523,7 @@ class MySpec extends FlatSpec with TestContainerForAll {
 }
 ```
 
-#### Example with multiple containers
+##### Example with multiple containers
 ```scala
 class MySpec extends FlatSpec with TestContainersForAll {
 


### PR DESCRIPTION
there is a section now on how to use the `start/stop` hooks with the new API of `testcontainers-scala` 